### PR TITLE
Unsubscribe resize on receivin a destroy event

### DIFF
--- a/man/resize.md
+++ b/man/resize.md
@@ -3,6 +3,9 @@
 A simple component that will dispatch through the DOM the `size-dirty` and `redraw` event whenever the window size changes.
 This is to be used for creating complex components where DOM geometry caches need to be expired on resize.
 
+The component works by attaching a `resize` event on `document.window`.
+If a `destroy` event is dispatched on the selection this component is called on, the component will deactivate by unsubscribing from the `resize` event.
+
 This can be used in conjunction with [redraw](./redraw.md)
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/d3-utils",
-  "version": "3.3.1",
+  "version": "3.4.0-unsubscribe-on-destroy.1",
   "description": "Common utility functions to use with d3",
   "keywords": [
     "d3"

--- a/src/resize.js
+++ b/src/resize.js
@@ -9,6 +9,7 @@ export function createResize() {
   let wait = 300
 
   function resize(s) {
+    s.on('destroy.resize', () => w.on(type, null))
     w.on(type, debounce(onWindowResize, wait))
 
     function onWindowResize() {


### PR DESCRIPTION
## Description

This gives a way to the user to unsubscribe from automatic `resize` events.
## Motivation and Context

When we destroy a grid, we desire to unattach its `resize` event from the window. Currently, grids will forever remain alive because the `resize` handler is kept alive by the reference in the resize component.
This PR gives the user a way to unsubscribe and make the component eligible for garbage collection.
## How Was This Tested?

Manually on @zambezi/grid
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
