### PR TITLE
Support redispatch same events work

### DIFF
--- a/src/redispatch.js
+++ b/src/redispatch.js
@@ -1,5 +1,6 @@
 import { dispatch as createDispatch } from 'd3-dispatch'
 import { createResize } from './rebind'
+import { unique } from 'underscore'
 
 export function redispatch() {
   const dispatchers = []
@@ -18,7 +19,10 @@ export function redispatch() {
   }
 
   redispatch.create = () => {
-    const dispatch = createDispatch.apply(null, dispatchers.reduce(types, []))
+    const dispatch = createDispatch.apply(
+            null
+          , unique(dispatchers.reduce(types, []))
+          )
 
     dispatchers.forEach(proxyEvents)
     return dispatch

--- a/test/redispatch_test.js
+++ b/test/redispatch_test.js
@@ -47,4 +47,20 @@ describe('redispatch', () => {
 
   })
 
+  it('should support redispatching the same event from multiple sources', () => {
+    const dispatcher1 = createDispatcher('a')
+        , dispatcher2 = createDispatcher('a')
+        , forward = redispatch()
+              .from(dispatcher1, 'a')
+              .from(dispatcher2, 'a')
+              ()
+
+    forward.on('a', e => strictEqual(e, 1))
+    dispatcher1.call('a', {}, 1)
+
+    forward.on('a', e => strictEqual(e, 2))
+    dispatcher2.call('a', {}, 2)
+
+  })
+
 })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. Screenshots (where appropriate) more than welcome! -->
With this PR `d3Utils.redispatch` allows proxying events with the same type from multiple sources.
Without this change `d3` would throw a RE if you tried to do this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->
On some components (the [WIP stacked grid](http://bl.ocks.org/gabrielmontagne/ca38bb27853b808ae4cf43d3840ada97), for example) we are aggregating events from several instances of the same components.
All these components dispatch the same type of event.  
`redispatch` is not able to aggregate this without this change.

## How Was This Tested?
<!--- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
A new test case has been added to cover for this use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
