### PR TITLE
Fix rollup watch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "mkdirp": "0.5.1",
     "mocha": "2.5.3",
     "rimraf": "2.5.3",
-    "rollup": "0.26.3",
-    "rollup-plugin-babel": "2.3.9"
+    "rollup": "^0.34.10",
+    "rollup-plugin-babel": "2.3.9",
+    "rollup-watch": "^2.5.0"
   },
   "dependencies": {
     "d3-dispatch": "^1.0.1",


### PR DESCRIPTION
## Description

Fixes `npm run watch` target, sames as https://github.com/zambezi/grid/pull/25



