### PR TITLE
add anti-dogpile-json to project

### DIFF
--- a/examples/browser.html
+++ b/examples/browser.html
@@ -8,6 +8,10 @@
 <script src="../node_modules/underscore/underscore.js"></script>
 <script src="../node_modules/d3-selection/build/d3-selection.js"></script>
 <script src="../node_modules/d3-dispatch/build/d3-dispatch.js"></script>
+<script src="../node_modules/d3-collection/build/d3-collection.js"></script>
+<script src="../node_modules/d3-dispatch/build/d3-dispatch.js"></script>
+<script src="../node_modules/d3-dsv/build/d3-dsv.js"></script>
+<script src="../node_modules/d3-request/build/d3-request.js"></script>
 <script src="../dist/d3-utils.js"></script>
 <script>
 

--- a/man/anti-dogpile-json.md
+++ b/man/anti-dogpile-json.md
@@ -1,0 +1,19 @@
+## anti dogpile json
+
+A replacement for `d3.json` (for *GET* calls) that will reuse live/in-flight requests for fetching the same URL.
+This is not a caching mechanism: as soon as the request loads, the request will be cleared.
+
+```javascript
+const json = createAntiDogpileJson()
+
+json(url)
+  .on('error', onError)
+  .on('load', onLoad)
+  .get()
+```
+
+### Rationale
+
+It can become difficult to prevent making networking calls to the same resource from one component, yet alone
+many components. To better manage this, a global or shared component can be used to provide an anti dogpile
+json instance, so that any live/in-flight requests can be used when fetching the same URL.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "prepublish": "npm test"
   },
   "standard": {
-    "env": [ "mocha" ]
+    "env": [
+      "mocha"
+    ]
   },
   "license": "MIT",
   "main": "dist/d3-utils.js",
@@ -39,6 +41,7 @@
   },
   "dependencies": {
     "d3-dispatch": "^1.0.1",
+    "d3-request": "^1.0.5",
     "d3-selection": "^1.0.2",
     "underscore": "^1.8.3"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,12 +6,18 @@ export default {
   dest: 'dist/d3-utils.js',
   format: 'umd',
   moduleName: 'd3Utils',
-  external: [ 'd3-selection', 'd3-dispatch', 'underscore' ],
+  external: [
+    'd3-selection',
+    'd3-dispatch',
+    'd3-request',
+    'underscore'
+  ],
   sourceMap: true,
   plugins: [ babel(babelrc()) ],
   globals: {
     'underscore': '_',
     'd3-selection': 'd3',
-    'd3-dispatch': 'd3'
+    'd3-dispatch': 'd3',
+    'd3-request': 'd3'
   }
 }

--- a/src/anti-dogpile-json.js
+++ b/src/anti-dogpile-json.js
@@ -1,0 +1,34 @@
+import { json } from 'd3-request'
+import { rebind } from './rebind'
+import { redispatch } from './redispatch'
+
+export function createAntiDogpileJson () {
+  const requestByURL = {}
+
+  function antiDogpileJson (url) {
+    const inFlight = !!requestByURL[url]
+    const request = requestByURL[url] || createRequest(url)
+    const dispatcher = redispatch()
+          .from(request, 'beforesend', 'progress', 'load', 'error')
+          .create()
+
+    return rebind().from(dispatcher, 'on')({
+      get () {
+        if (inFlight) return
+        request.get()
+      }
+    })
+  }
+
+  function createRequest (url) {
+    const request = json(url)
+        .on('load.dp error.dp', () => {
+          delete requestByURL[url]
+        })
+
+    requestByURL[url] = request
+    return request
+  }
+
+  return antiDogpileJson
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { appendFromTemplate } from './append-from-template'
 export { appendIfMissing } from './append-if-missing'
 export { call } from './call'
+export { createAntiDogpileJson } from './anti-dogpile-json'
 export { createAutoDirty } from './auto-dirty'
 export { createCharacterClassValidator } from './character-class-validator'
 export { createResize } from './resize'

--- a/src/redispatch.js
+++ b/src/redispatch.js
@@ -1,5 +1,5 @@
 import { dispatch as createDispatch } from 'd3-dispatch'
-import { unique } from 'underscore'
+import { unique, uniqueId } from 'underscore'
 
 export function redispatch () {
   const dispatchers = []
@@ -29,7 +29,7 @@ export function redispatch () {
     function proxyEvents (d) {
       d.types.forEach(proxyEvent)
       function proxyEvent (type) {
-        d.dispatcher.on(`${type}.redispatcher`, forward)
+        d.dispatcher.on(`${type}.redispatcher.${uniqueId()}`, forward)
         function forward () {
           dispatch.apply(type, this, arguments)
         }


### PR DESCRIPTION
Add mechanism for reusing in-flight requests that acts as a replacement for `d3.json`.

## Description

```javascript
const json = u3Utils.createAntiDogpileJson()

json(url)
  .on('error', onError)
  .on('load', onLoad)
  .get()
```

## Motivation and Context

It can become difficult to prevent making networking calls to the same resource from one component, yet alone many components. To better manage this, a global or shared component can be used to provide an anti dogpile json instance, so that any live/in-flight requests can be used when fetching the same URL.


## How Was This Tested?

Tested manually in example page, had to use http-server to serve content with a http:// url.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
